### PR TITLE
refactor: use file-scoped namespaces in all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ When I was configuring Kind with some applications, I felt some pain to organize
 | -c, --create-cluster  | Delete the cluster and create a new one  | - | - | - | - |
 | --sqlserver  | Install sqlserver chart on kind | localhost:1433 | 30000 | sa | P@ssword123 |
 | --postgres | Install postgres chart on kind  | localhost:5432 | 30001 | desenv | P@ssword123 |
-| --citus | Install citus chart with 2 nodes on kind | localhost:5432 | 30007 | desenv | P@ssword123 |
+| --citus | Install citus chart with 2 nodes on kind | localhost:5433 | 30007 | desenv | P@ssword123 |
 | --istio-ingress | Install istio-ingress chart on kind, this create the namespaces `istio-ingress` and `istio-system` | localhost:8081 http, localhost:8082 https, localhost:8083 status-port | 30004, 30005, 30006 | - | - |
 | --pg-admin  | Install pgadmin chart on kind | http://localhost:9000 | 30002 | desenv@local.com | P@ssword123 |
 | -nginx, --nginx-ingress | Install nginx-ingress chart on kind | http://localhost:8080 | 30003 | - | - |

--- a/src/KindxtApp/Charts/Citus/CitusChart.cs
+++ b/src/KindxtApp/Charts/Citus/CitusChart.cs
@@ -1,36 +1,35 @@
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace Kindxt.Charts.Citus
+namespace Kindxt.Charts.Citus;
+
+public class CitusChart : HelmChartBase, IHelmChart
 {
-    public class CitusChart : HelmChartBase, IHelmChart
+    private readonly KubectlProcess _kubectlProcess;
+
+    public CitusChart(HelmProcess helmProcess, KubectlProcess kubectlProcess) : base(helmProcess)
     {
-        private readonly KubectlProcess _kubectlProcess;
-
-        public CitusChart(HelmProcess helmProcess, KubectlProcess kubectlProcess) : base(helmProcess)
-        {
-            _kubectlProcess = kubectlProcess;
-        }
-        public void Install()
-        {
-            _kubectlProcess
-                .ExecuteCommand($"create namespace cert-manager", ignoreError: true);
-
-            base.InstallFromRepo("jetstack/cert-manager",
-                "jetstack",
-                "https://charts.jetstack.io",
-                "cert-manager",
-                @namespace: "cert-manager",
-                parameters: "--version v1.5.4 --set installCRDs=true");
-
-            base.InstallFromRepo("prates-charts/citus",
-                "prates-charts",
-                "https://sergioprates.github.io/prates-charts/",
-                "citus");
-        }
-
-        public string[] Parameters => new[] { "--citus" };
-        public string Description => "Install citus chart on kind";
-        public ExtraPortMapping[] GetPortMapping() => Ports.Citus;
+        _kubectlProcess = kubectlProcess;
     }
+    public void Install()
+    {
+        _kubectlProcess
+            .ExecuteCommand($"create namespace cert-manager", ignoreError: true);
+
+        base.InstallFromRepo("jetstack/cert-manager",
+            "jetstack",
+            "https://charts.jetstack.io",
+            "cert-manager",
+            @namespace: "cert-manager",
+            parameters: "--version v1.5.4 --set installCRDs=true");
+
+        base.InstallFromRepo("prates-charts/citus",
+            "prates-charts",
+            "https://sergioprates.github.io/prates-charts/",
+            "citus");
+    }
+
+    public string[] Parameters => new[] { "--citus" };
+    public string Description => "Install citus chart on kind";
+    public ExtraPortMapping[] GetPortMapping() => Ports.Citus;
 }

--- a/src/KindxtApp/Charts/HelmChartBase.cs
+++ b/src/KindxtApp/Charts/HelmChartBase.cs
@@ -1,34 +1,33 @@
 using Kindxt.Extensions;
 using Kindxt.Processes;
 
-namespace Kindxt.Charts
+namespace Kindxt.Charts;
+
+public abstract class HelmChartBase
 {
-    public abstract class HelmChartBase
+    private readonly HelmProcess _helmProcess;
+
+    public HelmChartBase(HelmProcess helmProcess)
     {
-        private readonly HelmProcess _helmProcess;
+        _helmProcess = helmProcess;
+    }
+    public virtual void InstallFromRepo(string chartName,
+        string repoName, 
+        string repoUrl, 
+        string releaseName,
+        string? configPath = null,
+        string @namespace = "default",
+        string parameters = "")
+    {
+        var configCommand = string.IsNullOrWhiteSpace(configPath) ? "" : $"-f {configPath}";
 
-        public HelmChartBase(HelmProcess helmProcess)
-        {
-            _helmProcess = helmProcess;
-        }
-        public virtual void InstallFromRepo(string chartName,
-            string repoName, 
-            string repoUrl, 
-            string releaseName,
-            string? configPath = null,
-            string @namespace = "default",
-            string parameters = "")
-        {
-            var configCommand = string.IsNullOrWhiteSpace(configPath) ? "" : $"-f {configPath}";
+        var versionCommand = string.IsNullOrWhiteSpace(parameters) ? "" : parameters;
 
-            var versionCommand = string.IsNullOrWhiteSpace(parameters) ? "" : parameters;
-
-            _helmProcess
-                .ExecuteCommand($"repo add {repoName} {repoUrl}", ignoreError: true)
-                .ExecuteCommand("repo update", ignoreError: true)
-                .ExecuteCommand($"uninstall {releaseName} -n {@namespace}", ignoreError: true)
-                .ExecuteCommand($"install {releaseName} {chartName} -n {@namespace} --wait --debug --timeout=5m {configCommand} {versionCommand}".Trim(),
-                    KindxtPath.GetProcessPath());
-        }
+        _helmProcess
+            .ExecuteCommand($"repo add {repoName} {repoUrl}", ignoreError: true)
+            .ExecuteCommand("repo update", ignoreError: true)
+            .ExecuteCommand($"uninstall {releaseName} -n {@namespace}", ignoreError: true)
+            .ExecuteCommand($"install {releaseName} {chartName} -n {@namespace} --wait --debug --timeout=5m {configCommand} {versionCommand}".Trim(),
+                KindxtPath.GetProcessPath());
     }
 }

--- a/src/KindxtApp/Charts/Istio/IstioChart.cs
+++ b/src/KindxtApp/Charts/Istio/IstioChart.cs
@@ -2,51 +2,50 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace Kindxt.Charts.Istio
+namespace Kindxt.Charts.Istio;
+
+public class IstioChart : HelmChartBase, IHelmChart
 {
-    public class IstioChart : HelmChartBase, IHelmChart
+    private readonly KubectlProcess _kubectlProcess;
+
+    public IstioChart(HelmProcess helmProcess, KubectlProcess kubectlProcess) : base(helmProcess)
     {
-        private readonly KubectlProcess _kubectlProcess;
-
-        public IstioChart(HelmProcess helmProcess, KubectlProcess kubectlProcess) : base(helmProcess)
-        {
-            _kubectlProcess = kubectlProcess;
-        }
-        public void Install()
-        {
-            var configDirectory = Path.Combine("Charts", "Istio");
-
-            _kubectlProcess
-                .ExecuteCommand($"create namespace istio-system", ignoreError: true)
-                .ExecuteCommand($"label namespace istio-system istio-injection=enabled --overwrite",
-                    ignoreError: true);
-
-            base.InstallFromRepo("istio/base",
-                "istio",
-                "https://istio-release.storage.googleapis.com/charts",
-                "istio-base",
-                @namespace: "istio-system");
-
-            base.InstallFromRepo("istio/istiod",
-                "istio",
-                "https://istio-release.storage.googleapis.com/charts",
-                "istiod",
-                Path.Combine(configDirectory, "istiod-config.yaml"),
-                @namespace: "istio-system");
-
-            var configFile = Path.Combine(configDirectory, "istio-ingress-config.yaml");
-            base.InstallFromRepo("istio/gateway",
-                "istio",
-                "https://istio-release.storage.googleapis.com/charts",
-                "istio-ingressgateway",
-                configFile,
-                @namespace: "istio-system");
-
-            _kubectlProcess.ExecuteCommand("apply -f gateway.yaml", Path.Combine(KindxtPath.GetProcessPath(), configDirectory));
-        }
-
-        public string[] Parameters => new[] { "--istio-ingress"};
-        public string Description => "Install istio-ingress chart on kind";
-        public ExtraPortMapping[] GetPortMapping() => Ports.Istio;
+        _kubectlProcess = kubectlProcess;
     }
+    public void Install()
+    {
+        var configDirectory = Path.Combine("Charts", "Istio");
+
+        _kubectlProcess
+            .ExecuteCommand($"create namespace istio-system", ignoreError: true)
+            .ExecuteCommand($"label namespace istio-system istio-injection=enabled --overwrite",
+                ignoreError: true);
+
+        base.InstallFromRepo("istio/base",
+            "istio",
+            "https://istio-release.storage.googleapis.com/charts",
+            "istio-base",
+            @namespace: "istio-system");
+
+        base.InstallFromRepo("istio/istiod",
+            "istio",
+            "https://istio-release.storage.googleapis.com/charts",
+            "istiod",
+            Path.Combine(configDirectory, "istiod-config.yaml"),
+            @namespace: "istio-system");
+
+        var configFile = Path.Combine(configDirectory, "istio-ingress-config.yaml");
+        base.InstallFromRepo("istio/gateway",
+            "istio",
+            "https://istio-release.storage.googleapis.com/charts",
+            "istio-ingressgateway",
+            configFile,
+            @namespace: "istio-system");
+
+        _kubectlProcess.ExecuteCommand("apply -f gateway.yaml", Path.Combine(KindxtPath.GetProcessPath(), configDirectory));
+    }
+
+    public string[] Parameters => new[] { "--istio-ingress"};
+    public string Description => "Install istio-ingress chart on kind";
+    public ExtraPortMapping[] GetPortMapping() => Ports.Istio;
 }

--- a/src/KindxtApp/Charts/NginxIngress/NginxIngressChart.cs
+++ b/src/KindxtApp/Charts/NginxIngress/NginxIngressChart.cs
@@ -1,25 +1,24 @@
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace Kindxt.Charts.NginxIngress
+namespace Kindxt.Charts.NginxIngress;
+
+public class NginxIngressChart : HelmChartBase, IHelmChart
 {
-    public class NginxIngressChart : HelmChartBase, IHelmChart
+    public NginxIngressChart(HelmProcess helmProcess) : base(helmProcess)
+    { }
+    public void Install()
     {
-        public NginxIngressChart(HelmProcess helmProcess) : base(helmProcess)
-        { }
-        public void Install()
-        {
-            var configDirectory = Path.Combine("Charts", "NginxIngress", "config.yaml");
+        var configDirectory = Path.Combine("Charts", "NginxIngress", "config.yaml");
 
-            base.InstallFromRepo("ingress-nginx/ingress-nginx",
-                "ingress-nginx",
-                "https://kubernetes.github.io/ingress-nginx",
-                "nginx-ingress",
-                configDirectory);
-        }
-
-        public string[] Parameters => new[] {"--nginx-ingress", "-nginx"};
-        public string Description => "Install nginx-ingress chart on kind";
-        public ExtraPortMapping[] GetPortMapping() => Ports.NginxIngress;
+        base.InstallFromRepo("ingress-nginx/ingress-nginx",
+            "ingress-nginx",
+            "https://kubernetes.github.io/ingress-nginx",
+            "nginx-ingress",
+            configDirectory);
     }
+
+    public string[] Parameters => new[] {"--nginx-ingress", "-nginx"};
+    public string Description => "Install nginx-ingress chart on kind";
+    public ExtraPortMapping[] GetPortMapping() => Ports.NginxIngress;
 }

--- a/src/KindxtApp/Charts/PgAdmin/PgAdminChart.cs
+++ b/src/KindxtApp/Charts/PgAdmin/PgAdminChart.cs
@@ -1,25 +1,24 @@
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace Kindxt.Charts.Adminer
+namespace Kindxt.Charts.Adminer;
+
+public class PgAdminChart : HelmChartBase, IHelmChart
 {
-    public class PgAdminChart : HelmChartBase, IHelmChart
+    public PgAdminChart(HelmProcess helmProcess) : base(helmProcess)
+    { }
+    public void Install()
     {
-        public PgAdminChart(HelmProcess helmProcess) : base(helmProcess)
-        { }
-        public void Install()
-        {
-            var configDirectory = Path.Combine("Charts", "PgAdmin", "config.yaml");
+        var configDirectory = Path.Combine("Charts", "PgAdmin", "config.yaml");
 
-            base.InstallFromRepo("runix/pgadmin4",
-                "runix",
-                "https://helm.runix.net",
-                "pgadmin",
-                configDirectory);
-        }
-
-        public string[] Parameters => new[] { "--pg-admin", "-pssql-admin" };
-        public string Description => "Install pgadmin chart on kind";
-        public ExtraPortMapping[] GetPortMapping() => Ports.PgAdmin;
+        base.InstallFromRepo("runix/pgadmin4",
+            "runix",
+            "https://helm.runix.net",
+            "pgadmin",
+            configDirectory);
     }
+
+    public string[] Parameters => new[] { "--pg-admin", "-pssql-admin" };
+    public string Description => "Install pgadmin chart on kind";
+    public ExtraPortMapping[] GetPortMapping() => Ports.PgAdmin;
 }

--- a/src/KindxtApp/Charts/Postgres/PostgresChart.cs
+++ b/src/KindxtApp/Charts/Postgres/PostgresChart.cs
@@ -1,25 +1,24 @@
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace Kindxt.Charts.Postgres
+namespace Kindxt.Charts.Postgres;
+
+public class PostgresChart : HelmChartBase, IHelmChart
 {
-    public class PostgresChart : HelmChartBase, IHelmChart
+    public PostgresChart(HelmProcess helmProcess) : base(helmProcess)
+    { }
+    public void Install()
     {
-        public PostgresChart(HelmProcess helmProcess) : base(helmProcess)
-        { }
-        public void Install()
-        {
-            var configDirectory = Path.Combine("Charts", "Postgres", "config.yaml");
+        var configDirectory = Path.Combine("Charts", "Postgres", "config.yaml");
 
-            base.InstallFromRepo("bitnami/postgresql",
-                "bitnami",
-                "https://charts.bitnami.com/bitnami",
-                "postgres",
-                configDirectory);
-        }
-
-        public string[] Parameters => new[] { "--postgres", "-pssql" };
-        public string Description => "Install postgres chart on kind";
-        public ExtraPortMapping[] GetPortMapping() => Ports.Postgres;
+        base.InstallFromRepo("bitnami/postgresql",
+            "bitnami",
+            "https://charts.bitnami.com/bitnami",
+            "postgres",
+            configDirectory);
     }
+
+    public string[] Parameters => new[] { "--postgres", "-pssql" };
+    public string Description => "Install postgres chart on kind";
+    public ExtraPortMapping[] GetPortMapping() => Ports.Postgres;
 }

--- a/src/KindxtApp/Commands/ICommandParameter.cs
+++ b/src/KindxtApp/Commands/ICommandParameter.cs
@@ -1,11 +1,10 @@
-﻿using Kindxt.Kind;
+using Kindxt.Kind;
 
-namespace Kindxt.Commands
+namespace Kindxt.Commands;
+
+public interface ICommandParameter
 {
-    public interface ICommandParameter
-    {
-        List<string> Parameters { get; set; }
-        void Execute();
-        ExtraPortMapping GetPortMapping();
-    }
+    List<string> Parameters { get; set; }
+    void Execute();
+    ExtraPortMapping GetPortMapping();
 }

--- a/src/KindxtApp/Commands/KindxtRootCommand.cs
+++ b/src/KindxtApp/Commands/KindxtRootCommand.cs
@@ -2,23 +2,22 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using Kindxt.Kind;
 
-namespace Kindxt.Commands
+namespace Kindxt.Commands;
+
+public class KindxtRootCommand : RootCommand
 {
-    public class KindxtRootCommand : RootCommand
+    private readonly IServiceProvider _serviceProvider;
+
+    public KindxtRootCommand(IServiceProvider serviceProvider)
+        : base("Kindxt is a extension from kind") =>
+        _serviceProvider = serviceProvider;
+
+    public void RegisterHandler(KindClusterBuilder kindClusterBuilder)
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        public KindxtRootCommand(IServiceProvider serviceProvider)
-            : base("Kindxt is a extension from kind") =>
-            _serviceProvider = serviceProvider;
-
-        public void RegisterHandler(KindClusterBuilder kindClusterBuilder)
+        this.SetHandler<List<string>, InvocationContext>((parameters,
+            ctx) =>
         {
-            this.SetHandler<List<string>, InvocationContext>((parameters,
-                ctx) =>
-            {
-                kindClusterBuilder.Build(parameters);
-            }, new ParametersBinder(this, _serviceProvider));
-        }
+            kindClusterBuilder.Build(parameters);
+        }, new ParametersBinder(this, _serviceProvider));
     }
 }

--- a/src/KindxtApp/Extensions/KindxtPath.cs
+++ b/src/KindxtApp/Extensions/KindxtPath.cs
@@ -1,7 +1,6 @@
-﻿namespace Kindxt.Extensions
+namespace Kindxt.Extensions;
+
+public static class KindxtPath
 {
-    public static class KindxtPath
-    {
-        public static string GetProcessPath() => Path.GetDirectoryName(Environment.ProcessPath!)!;
-    }
+    public static string GetProcessPath() => Path.GetDirectoryName(Environment.ProcessPath!)!;
 }

--- a/src/KindxtApp/Extensions/TypeExtensions.cs
+++ b/src/KindxtApp/Extensions/TypeExtensions.cs
@@ -1,10 +1,9 @@
-namespace Kindxt.Extensions
+namespace Kindxt.Extensions;
+
+public static class TypeExtensions
 {
-    public static class TypeExtensions
-    {
-        public static IEnumerable<Type> GetAllTypes<T>() =>
-            System.Reflection.Assembly.GetExecutingAssembly()
-                .GetTypes()
-                .Where(type => typeof(T).IsAssignableFrom(type) && !type.IsInterface);
-    }
+    public static IEnumerable<Type> GetAllTypes<T>() =>
+        System.Reflection.Assembly.GetExecutingAssembly()
+            .GetTypes()
+            .Where(type => typeof(T).IsAssignableFrom(type) && !type.IsInterface);
 }

--- a/src/KindxtApp/Kind/Ports.cs
+++ b/src/KindxtApp/Kind/Ports.cs
@@ -1,76 +1,75 @@
-namespace Kindxt.Kind
+namespace Kindxt.Kind;
+
+public static class Ports
 {
-    public static class Ports
+    private static string _protocol = "TCP";
+
+    public static ExtraPortMapping[] SqlServer => new ExtraPortMapping[]
     {
-        private static string _protocol = "TCP";
+        new()
+        {
+            ContainerPort = 30000,
+            HostPort = 1433,
+            Protocol = _protocol
+        }
+    };
+    public static ExtraPortMapping[] Postgres => new ExtraPortMapping[]
+    {
+        new()
+        {
+            ContainerPort = 30001,
+            HostPort = 5432,
+            Protocol = _protocol
+        }
+    };
+    public static ExtraPortMapping[] PgAdmin => new ExtraPortMapping[]
+    {
+        new ()
+        {
+            ContainerPort = 30002,
+            HostPort = 9000,
+            Protocol = _protocol
+        }
+    };
+    public static ExtraPortMapping[] NginxIngress => new ExtraPortMapping[]
+    {
+        new()
+        {
+            ContainerPort = 30003,
+            HostPort = 8080,
+            Protocol = _protocol
+        }
+    };
+    public static ExtraPortMapping[] Istio => new ExtraPortMapping[]
+    {
+        new()
+        {
+            ContainerPort = 30004,
+            HostPort = 8081,
+            Protocol = _protocol
+        },
+        new()
+        {
+            ContainerPort = 30005,
+            HostPort = 8082,
+            Protocol = _protocol
+        },
+        new()
+        {
+            ContainerPort = 30006,
+            HostPort = 8083,
+            Protocol = _protocol
+        },
+    };
+    public static ExtraPortMapping[] Citus => new ExtraPortMapping[]
+    {
+        new()
+        {
+            ContainerPort = 30007,
+            HostPort = 5433,
+            Protocol = _protocol
+        }
+    };
 
-        public static ExtraPortMapping[] SqlServer => new ExtraPortMapping[]
-        {
-            new()
-            {
-                ContainerPort = 30000,
-                HostPort = 1433,
-                Protocol = _protocol
-            }
-        };
-        public static ExtraPortMapping[] Postgres => new ExtraPortMapping[]
-        {
-            new()
-            {
-                ContainerPort = 30001,
-                HostPort = 5432,
-                Protocol = _protocol
-            }
-        };
-        public static ExtraPortMapping[] PgAdmin => new ExtraPortMapping[]
-        {
-            new ()
-            {
-                ContainerPort = 30002,
-                HostPort = 9000,
-                Protocol = _protocol
-            }
-        };
-        public static ExtraPortMapping[] NginxIngress => new ExtraPortMapping[]
-        {
-            new()
-            {
-                ContainerPort = 30003,
-                HostPort = 8080,
-                Protocol = _protocol
-            }
-        };
-        public static ExtraPortMapping[] Istio => new ExtraPortMapping[]
-        {
-            new()
-            {
-                ContainerPort = 30004,
-                HostPort = 8081,
-                Protocol = _protocol
-            },
-            new()
-            {
-                ContainerPort = 30005,
-                HostPort = 8082,
-                Protocol = _protocol
-            },
-            new()
-            {
-                ContainerPort = 30006,
-                HostPort = 8083,
-                Protocol = _protocol
-            },
-        };
-        public static ExtraPortMapping[] Citus => new ExtraPortMapping[]
-        {
-            new()
-            {
-                ContainerPort = 30007,
-                HostPort = 5433,
-                Protocol = _protocol
-            }
-        };
-
-        public static ExtraPortMapping[] CertManager => new ExtraPortMapping[] { };
-    }
+    public static ExtraPortMapping[] CertManager => new ExtraPortMapping[] { };
 }

--- a/src/KindxtApp/Managers/FileManager.cs
+++ b/src/KindxtApp/Managers/FileManager.cs
@@ -1,21 +1,20 @@
 using System.Text;
 
-namespace Kindxt.Managers
+namespace Kindxt.Managers;
+
+public class FileManager
 {
-    public class FileManager
+    public virtual void CreateDirectoryIfNotExists(string path)
     {
-        public virtual void CreateDirectoryIfNotExists(string path)
-        {
-            if (!Directory.Exists(path))
-                Directory.CreateDirectory(path);
-        }
-        public virtual void WriteFile(string path, string content)
-        {
-            File.WriteAllText(path, content, Encoding.UTF8);
-        }
-        public virtual TextReader GetReader(string path)
-        {
-            return new StreamReader(path);
-        }
+        if (!Directory.Exists(path))
+            Directory.CreateDirectory(path);
+    }
+    public virtual void WriteFile(string path, string content)
+    {
+        File.WriteAllText(path, content, Encoding.UTF8);
+    }
+    public virtual TextReader GetReader(string path)
+    {
+        return new StreamReader(path);
     }
 }

--- a/src/KindxtApp/Managers/HelmChartManager.cs
+++ b/src/KindxtApp/Managers/HelmChartManager.cs
@@ -2,22 +2,21 @@ using Kindxt.Charts;
 using Kindxt.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Kindxt.Managers
+namespace Kindxt.Managers;
+
+public class HelmChartManager
 {
-    public class HelmChartManager
+    private readonly IServiceProvider _serviceProvider;
+
+    public HelmChartManager(IServiceProvider serviceProvider)
     {
-        private readonly IServiceProvider _serviceProvider;
+        _serviceProvider = serviceProvider;
+    }
+    public virtual List<IHelmChart> GetHelmCharts(List<string> parameters)
+    {
+        var helmChartsAvailable = TypeExtensions.GetAllTypes<IHelmChart>().Select(type => (IHelmChart)_serviceProvider.GetRequiredService(type));
 
-        public HelmChartManager(IServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-        public virtual List<IHelmChart> GetHelmCharts(List<string> parameters)
-        {
-            var helmChartsAvailable = TypeExtensions.GetAllTypes<IHelmChart>().Select(type => (IHelmChart)_serviceProvider.GetRequiredService(type));
-
-            return helmChartsAvailable.Where(helmChart =>
-                helmChart.Parameters.Any(parameters.Contains)).ToList();
-        }
+        return helmChartsAvailable.Where(helmChart =>
+            helmChart.Parameters.Any(parameters.Contains)).ToList();
     }
 }

--- a/src/KindxtApp/Processes/HelmProcess.cs
+++ b/src/KindxtApp/Processes/HelmProcess.cs
@@ -1,9 +1,8 @@
-﻿namespace Kindxt.Processes
+namespace Kindxt.Processes;
+
+public class HelmProcess : ProcessWrapper
 {
-    public class HelmProcess : ProcessWrapper
-    {
-        public HelmProcess()
-            : base("helm")
-        { }
-    }
+    public HelmProcess()
+        : base("helm")
+    { }
 }

--- a/src/KindxtApp/Processes/KindProcess.cs
+++ b/src/KindxtApp/Processes/KindProcess.cs
@@ -1,9 +1,8 @@
-﻿namespace Kindxt.Processes
+namespace Kindxt.Processes;
+
+public class KindProcess : ProcessWrapper
 {
-    public class KindProcess : ProcessWrapper
-    {
-        public KindProcess()
-          : base("kind")
-        { }
-    }
+    public KindProcess()
+      : base("kind")
+    { }
 }

--- a/src/KindxtApp/Processes/KubectlProcess.cs
+++ b/src/KindxtApp/Processes/KubectlProcess.cs
@@ -1,9 +1,8 @@
-namespace Kindxt.Processes
+namespace Kindxt.Processes;
+
+public class KubectlProcess : ProcessWrapper
 {
-    public class KubectlProcess : ProcessWrapper
-    {
-        public KubectlProcess()
-           : base("kubectl")
-        { }
-    }
+    public KubectlProcess()
+       : base("kubectl")
+    { }
 }

--- a/tests/UnitTests/Charts/Citus/CertManagerChartTests.cs
+++ b/tests/UnitTests/Charts/Citus/CertManagerChartTests.cs
@@ -10,59 +10,58 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace UnitTests.Charts.Citus
+namespace UnitTests.Charts.Citus;
+
+internal class CertManagerChartTests : TestBase
 {
-    internal class CertManagerChartTests : TestBase
+    private const string ReleaseName = "cert-manager";
+    private const string Namespace = "cert-manager";
+    private const string ChartName = "jetstack/cert-manager";
+    private const string RepoName = "jetstack";
+    private const string RepoUrl = "https://charts.jetstack.io";
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "cert-manager";
-        private const string Namespace = "cert-manager";
-        private const string ChartName = "jetstack/cert-manager";
-        private const string RepoName = "jetstack";
-        private const string RepoUrl = "https://charts.jetstack.io";
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        AutoFake.Provide(A.Fake<KubectlProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<KubectlProcess>());
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            AutoFake.Provide(A.Fake<KubectlProcess>());
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
-            A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<KubectlProcess>());
-        }
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
-
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m  --version v1.5.4 --set installCRDs=true",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m  --version v1.5.4 --set installCRDs=true",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/Citus/CitusChartTests.cs
+++ b/tests/UnitTests/Charts/Citus/CitusChartTests.cs
@@ -5,96 +5,95 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.Citus
+namespace UnitTests.Charts.Citus;
+
+public class CitusChartTests : TestBase
 {
-    public class CitusChartTests : TestBase
+    private const string ReleaseName = "citus";
+    private const string Namespace = "default";
+    private const string ChartName = "prates-charts/citus";
+    private const string RepoName = "prates-charts";
+    private const string RepoUrl = "https://sergioprates.github.io/prates-charts/";
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "citus";
-        private const string Namespace = "default";
-        private const string ChartName = "prates-charts/citus";
-        private const string RepoName = "prates-charts";
-        private const string RepoUrl = "https://sergioprates.github.io/prates-charts/";
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        AutoFake.Provide(A.Fake<KubectlProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<KubectlProcess>());
+    }
+    [Test]
+    public void ParametersShouldBeCorrect()
+    {
+        AutoFake.Resolve<CitusChart>().Parameters
+            .Should().BeEquivalentTo(new string[] { "--citus" });
+    }
+    [Test]
+    public void DescriptionShouldBeCorrect()
+    {
+        AutoFake.Resolve<CitusChart>().Description
+            .Should().Be("Install citus chart on kind");
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            AutoFake.Provide(A.Fake<KubectlProcess>());
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
-            A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<KubectlProcess>());
-        }
-        [Test]
-        public void ParametersShouldBeCorrect()
-        {
-            AutoFake.Resolve<CitusChart>().Parameters
-                .Should().BeEquivalentTo(new string[] { "--citus" });
-        }
-        [Test]
-        public void DescriptionShouldBeCorrect()
-        {
-            AutoFake.Resolve<CitusChart>().Description
-                .Should().Be("Install citus chart on kind");
-        }
-
-        [Test]
-        public void GetPortMappingShouldReturnCorrectMap()
-        {
-            AutoFake.Resolve<CitusChart>().GetPortMapping()
-                .Should().BeEquivalentTo(new ExtraPortMapping[]
+    [Test]
+    public void GetPortMappingShouldReturnCorrectMap()
+    {
+        AutoFake.Resolve<CitusChart>().GetPortMapping()
+            .Should().BeEquivalentTo(new ExtraPortMapping[]
+            {
+                new()
                 {
-                    new()
-                    {
-                        ContainerPort = 30007,
-                        HostPort = 5433,
-                        Protocol = "TCP"
-                    }
-                });
-        }
+                    ContainerPort = 30007,
+                    HostPort = 5433,
+                    Protocol = "TCP"
+                }
+            });
+    }
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceOrMore();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceOrMore();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<CitusChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<CitusChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/Istio/IstioBaseTests.cs
+++ b/tests/UnitTests/Charts/Istio/IstioBaseTests.cs
@@ -3,71 +3,70 @@ using Kindxt.Charts.Istio;
 using Kindxt.Extensions;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.Istio
+namespace UnitTests.Charts.Istio;
+
+public class IstioBaseTests : TestBase
 {
-    public class IstioBaseTests : TestBase
+    private const string ReleaseName = "istio-base";
+    private const string Namespace = "istio-system";
+    private const string ChartName = "istio/base";
+    private const string RepoName = "istio";
+    private const string RepoUrl = "https://istio-release.storage.googleapis.com/charts";
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "istio-base";
-        private const string Namespace = "istio-system";
-        private const string ChartName = "istio/base";
-        private const string RepoName = "istio";
-        private const string RepoUrl = "https://istio-release.storage.googleapis.com/charts";
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        AutoFake.Provide(A.Fake<KubectlProcess>());
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            AutoFake.Provide(A.Fake<KubectlProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<KubectlProcess>());
+    }
 
-            A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<KubectlProcess>());
-        }
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappened();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappened();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappened();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappened();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
-
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/Istio/IstioChartTests.cs
+++ b/tests/UnitTests/Charts/Istio/IstioChartTests.cs
@@ -5,98 +5,97 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.Istio
+namespace UnitTests.Charts.Istio;
+
+public class IstioChartTests : TestBase
 {
-    public class IstioChartTests : TestBase
+    [SetUp]
+    public void SetUp()
     {
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            AutoFake.Provide(A.Fake<KubectlProcess>());
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        AutoFake.Provide(A.Fake<KubectlProcess>());
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
 
-            A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<KubectlProcess>());
-        }
+        A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<KubectlProcess>());
+    }
 
-        [Test]
-        public void ParametersShouldBeCorrect()
-        {
-            AutoFake.Resolve<IstioChart>().Parameters
-                .Should().BeEquivalentTo(new string[] { "--istio-ingress" });
-        }
-        [Test]
-        public void DescriptionShouldBeCorrect()
-        {
-            AutoFake.Resolve<IstioChart>().Description
-                .Should().Be("Install istio-ingress chart on kind");
-        }
+    [Test]
+    public void ParametersShouldBeCorrect()
+    {
+        AutoFake.Resolve<IstioChart>().Parameters
+            .Should().BeEquivalentTo(new string[] { "--istio-ingress" });
+    }
+    [Test]
+    public void DescriptionShouldBeCorrect()
+    {
+        AutoFake.Resolve<IstioChart>().Description
+            .Should().Be("Install istio-ingress chart on kind");
+    }
 
-        [Test]
-        public void GetPortMappingShouldReturnCorrectMap()
-        {
-            AutoFake.Resolve<IstioChart>().GetPortMapping()
-                .Should().BeEquivalentTo(new ExtraPortMapping[]
-                {
-                        new()
-                        {
-                            ContainerPort = 30004,
-                            HostPort = 8081,
-                            Protocol = "TCP"
-                        },
-                        new()
-                        {
-                            ContainerPort = 30005,
-                            HostPort = 8082,
-                            Protocol = "TCP"
-                        },
-                        new()
-                        {
-                            ContainerPort = 30006,
-                            HostPort = 8083,
-                            Protocol = "TCP"
-                        },
-                });
-        }
+    [Test]
+    public void GetPortMappingShouldReturnCorrectMap()
+    {
+        AutoFake.Resolve<IstioChart>().GetPortMapping()
+            .Should().BeEquivalentTo(new ExtraPortMapping[]
+            {
+                    new()
+                    {
+                        ContainerPort = 30004,
+                        HostPort = 8081,
+                        Protocol = "TCP"
+                    },
+                    new()
+                    {
+                        ContainerPort = 30005,
+                        HostPort = 8082,
+                        Protocol = "TCP"
+                    },
+                    new()
+                    {
+                        ContainerPort = 30006,
+                        HostPort = 8083,
+                        Protocol = "TCP"
+                    },
+            });
+    }
 
-        [Test]
-        public void ShouldCreateNamespaceIstioSystem()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+    [Test]
+    public void ShouldCreateNamespaceIstioSystem()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<KubectlProcess>().ExecuteCommand(
-                        "create namespace istio-system", A<string>.Ignored, true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+                AutoFake.Resolve<KubectlProcess>().ExecuteCommand(
+                    "create namespace istio-system", A<string>.Ignored, true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [Test]
-        public void ShouldLabelNamespaceIstioSystemWithIstioInjection()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+    [Test]
+    public void ShouldLabelNamespaceIstioSystemWithIstioInjection()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<KubectlProcess>().ExecuteCommand(
-                        "label namespace istio-system istio-injection=enabled --overwrite", A<string>.Ignored, true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+                AutoFake.Resolve<KubectlProcess>().ExecuteCommand(
+                    "label namespace istio-system istio-injection=enabled --overwrite", A<string>.Ignored, true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [Test]
-        public void ShouldCreateDefaultGatewayOnK8s()
-        {
-            var configDirectory = Path.Combine("Charts", "Istio");
+    [Test]
+    public void ShouldCreateDefaultGatewayOnK8s()
+    {
+        var configDirectory = Path.Combine("Charts", "Istio");
 
-            AutoFake.Resolve<IstioChart>().Install();
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<KubectlProcess>().ExecuteCommand(
-                        "apply -f gateway.yaml", Path.Combine(KindxtPath.GetProcessPath(), configDirectory), false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+                AutoFake.Resolve<KubectlProcess>().ExecuteCommand(
+                    "apply -f gateway.yaml", Path.Combine(KindxtPath.GetProcessPath(), configDirectory), false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/Istio/IstioIngressGatewayTests.cs
+++ b/tests/UnitTests/Charts/Istio/IstioIngressGatewayTests.cs
@@ -5,72 +5,71 @@ using Kindxt.Extensions;
 using Kindxt.Processes;
 using NUnit.Framework.Internal;
 
-namespace UnitTests.Charts.Istio
+namespace UnitTests.Charts.Istio;
+
+public class IstioIngressGatewayTests : TestBase
 {
-    public class IstioIngressGatewayTests : TestBase
+    private const string ReleaseName = "istio-ingressgateway";
+    private const string Namespace = "istio-system";
+    private const string ChartName = "istio/gateway";
+    private const string RepoName = "istio";
+    private const string RepoUrl = "https://istio-release.storage.googleapis.com/charts";
+    private string _pathConfig = Path.Combine("Charts", "Istio", "istio-ingress-config.yaml");
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "istio-ingressgateway";
-        private const string Namespace = "istio-system";
-        private const string ChartName = "istio/gateway";
-        private const string RepoName = "istio";
-        private const string RepoUrl = "https://istio-release.storage.googleapis.com/charts";
-        private string _pathConfig = Path.Combine("Charts", "Istio", "istio-ingress-config.yaml");
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        AutoFake.Provide(A.Fake<KubectlProcess>());
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            AutoFake.Provide(A.Fake<KubectlProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<KubectlProcess>());
+    }
 
-            A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<KubectlProcess>());
-        }
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappened();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappened();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappened();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappened();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
-
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/Istio/IstiodTests.cs
+++ b/tests/UnitTests/Charts/Istio/IstiodTests.cs
@@ -3,72 +3,71 @@ using Kindxt.Charts.Istio;
 using Kindxt.Extensions;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.Istio
+namespace UnitTests.Charts.Istio;
+
+public class IstiodTests : TestBase
 {
-    public class IstiodTests : TestBase
+    private const string ReleaseName = "istiod";
+    private const string Namespace = "istio-system";
+    private const string ChartName = "istio/istiod";
+    private const string RepoName = "istio";
+    private const string RepoUrl = "https://istio-release.storage.googleapis.com/charts";
+    private string _pathConfig = Path.Combine("Charts", "Istio", "istiod-config.yaml");
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "istiod";
-        private const string Namespace = "istio-system";
-        private const string ChartName = "istio/istiod";
-        private const string RepoName = "istio";
-        private const string RepoUrl = "https://istio-release.storage.googleapis.com/charts";
-        private string _pathConfig = Path.Combine("Charts", "Istio", "istiod-config.yaml");
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        AutoFake.Provide(A.Fake<KubectlProcess>());
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            AutoFake.Provide(A.Fake<KubectlProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<KubectlProcess>());
+    }
 
-            A.CallTo(() => AutoFake.Resolve<KubectlProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<KubectlProcess>());
-        }
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappened();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappened();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappened();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappened();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<IstioChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<IstioChart>().Install();
-
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/NginxIngress/NginxIngressChartTests.cs
+++ b/tests/UnitTests/Charts/NginxIngress/NginxIngressChartTests.cs
@@ -5,93 +5,92 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.NginxIngress
+namespace UnitTests.Charts.NginxIngress;
+
+public class NginxIngressChartTests : TestBase
 {
-    public class NginxIngressChartTests : TestBase
+    private const string ReleaseName = "nginx-ingress";
+    private const string Namespace = "default";
+    private const string ChartName = "ingress-nginx/ingress-nginx";
+    private const string RepoName = "ingress-nginx";
+    private const string RepoUrl = "https://kubernetes.github.io/ingress-nginx";
+    private string _pathConfig = Path.Combine("Charts", "NginxIngress", "config.yaml");
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "nginx-ingress";
-        private const string Namespace = "default";
-        private const string ChartName = "ingress-nginx/ingress-nginx";
-        private const string RepoName = "ingress-nginx";
-        private const string RepoUrl = "https://kubernetes.github.io/ingress-nginx";
-        private string _pathConfig = Path.Combine("Charts", "NginxIngress", "config.yaml");
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
+    }
+    [Test]
+    public void ParametersShouldBeCorrect()
+    {
+        AutoFake.Resolve<NginxIngressChart>().Parameters
+            .Should().BeEquivalentTo(new string[] { "--nginx-ingress", "-nginx" });
+    }
+    [Test]
+    public void DescriptionShouldBeCorrect()
+    {
+        AutoFake.Resolve<NginxIngressChart>().Description
+            .Should().Be("Install nginx-ingress chart on kind");
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
-        }
-        [Test]
-        public void ParametersShouldBeCorrect()
-        {
-            AutoFake.Resolve<NginxIngressChart>().Parameters
-                .Should().BeEquivalentTo(new string[] { "--nginx-ingress", "-nginx" });
-        }
-        [Test]
-        public void DescriptionShouldBeCorrect()
-        {
-            AutoFake.Resolve<NginxIngressChart>().Description
-                .Should().Be("Install nginx-ingress chart on kind");
-        }
-
-        [Test]
-        public void GetPortMappingShouldReturnCorrectMap()
-        {
-            AutoFake.Resolve<NginxIngressChart>().GetPortMapping()
-                .Should().BeEquivalentTo(new ExtraPortMapping[]
+    [Test]
+    public void GetPortMappingShouldReturnCorrectMap()
+    {
+        AutoFake.Resolve<NginxIngressChart>().GetPortMapping()
+            .Should().BeEquivalentTo(new ExtraPortMapping[]
+            {
+                new()
                 {
-                    new()
-                    {
-                        ContainerPort = 30003,
-                        HostPort = 8080,
-                        Protocol = "TCP"
-                    }
-                });
-        }
+                    ContainerPort = 30003,
+                    HostPort = 8080,
+                    Protocol = "TCP"
+                }
+            });
+    }
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<NginxIngressChart>().Install();
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<NginxIngressChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<NginxIngressChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<NginxIngressChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<NginxIngressChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<NginxIngressChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<NginxIngressChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<NginxIngressChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/PgAdmin/PgAdminChartTests.cs
+++ b/tests/UnitTests/Charts/PgAdmin/PgAdminChartTests.cs
@@ -5,93 +5,92 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.PgAdmin
+namespace UnitTests.Charts.PgAdmin;
+
+public class PgAdminChartTests : TestBase
 {
-    public class PgAdminChartTests : TestBase
+    private const string ReleaseName = "pgadmin";
+    private const string Namespace = "default";
+    private const string ChartName = "runix/pgadmin4";
+    private const string RepoName = "runix";
+    private const string RepoUrl = "https://helm.runix.net";
+    private string _pathConfig = Path.Combine("Charts", "PgAdmin", "config.yaml");
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "pgadmin";
-        private const string Namespace = "default";
-        private const string ChartName = "runix/pgadmin4";
-        private const string RepoName = "runix";
-        private const string RepoUrl = "https://helm.runix.net";
-        private string _pathConfig = Path.Combine("Charts", "PgAdmin", "config.yaml");
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
+    }
+    [Test]
+    public void ParametersShouldBeCorrect()
+    {
+        AutoFake.Resolve<PgAdminChart>().Parameters
+            .Should().BeEquivalentTo(new string[] { "--pg-admin", "-pssql-admin" });
+    }
+    [Test]
+    public void DescriptionShouldBeCorrect()
+    {
+        AutoFake.Resolve<PgAdminChart>().Description
+            .Should().Be("Install pgadmin chart on kind");
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
-        }
-        [Test]
-        public void ParametersShouldBeCorrect()
-        {
-            AutoFake.Resolve<PgAdminChart>().Parameters
-                .Should().BeEquivalentTo(new string[] { "--pg-admin", "-pssql-admin" });
-        }
-        [Test]
-        public void DescriptionShouldBeCorrect()
-        {
-            AutoFake.Resolve<PgAdminChart>().Description
-                .Should().Be("Install pgadmin chart on kind");
-        }
-
-        [Test]
-        public void GetPortMappingShouldReturnCorrectMap()
-        {
-            AutoFake.Resolve<PgAdminChart>().GetPortMapping()
-                .Should().BeEquivalentTo(new ExtraPortMapping[]
+    [Test]
+    public void GetPortMappingShouldReturnCorrectMap()
+    {
+        AutoFake.Resolve<PgAdminChart>().GetPortMapping()
+            .Should().BeEquivalentTo(new ExtraPortMapping[]
+            {
+                new()
                 {
-                    new()
-                    {
-                        ContainerPort = 30002,
-                        HostPort = 9000,
-                        Protocol = "TCP"
-                    }
-                });
-        }
+                    ContainerPort = 30002,
+                    HostPort = 9000,
+                    Protocol = "TCP"
+                }
+            });
+    }
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<PgAdminChart>().Install();
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<PgAdminChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<PgAdminChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<PgAdminChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<PgAdminChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<PgAdminChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<PgAdminChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<PgAdminChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/Postgres/PostgresChartTests.cs
+++ b/tests/UnitTests/Charts/Postgres/PostgresChartTests.cs
@@ -5,93 +5,92 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.Postgres
+namespace UnitTests.Charts.Postgres;
+
+public class PostgresChartTests : TestBase
 {
-    public class PostgresChartTests : TestBase
+    private const string ReleaseName = "postgres";
+    private const string Namespace = "default";
+    private const string ChartName = "bitnami/postgresql";
+    private const string RepoName = "bitnami";
+    private const string RepoUrl = "https://charts.bitnami.com/bitnami";
+    private string _pathConfig = Path.Combine("Charts", "Postgres", "config.yaml");
+
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "postgres";
-        private const string Namespace = "default";
-        private const string ChartName = "bitnami/postgresql";
-        private const string RepoName = "bitnami";
-        private const string RepoUrl = "https://charts.bitnami.com/bitnami";
-        private string _pathConfig = Path.Combine("Charts", "Postgres", "config.yaml");
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
+    }
+    [Test]
+    public void ParametersShouldBeCorrect()
+    {
+        AutoFake.Resolve<PostgresChart>().Parameters
+            .Should().BeEquivalentTo(new string[] { "--postgres", "-pssql" });
+    }
+    [Test]
+    public void DescriptionShouldBeCorrect()
+    {
+        AutoFake.Resolve<PostgresChart>().Description
+            .Should().Be("Install postgres chart on kind");
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
-        }
-        [Test]
-        public void ParametersShouldBeCorrect()
-        {
-            AutoFake.Resolve<PostgresChart>().Parameters
-                .Should().BeEquivalentTo(new string[] { "--postgres", "-pssql" });
-        }
-        [Test]
-        public void DescriptionShouldBeCorrect()
-        {
-            AutoFake.Resolve<PostgresChart>().Description
-                .Should().Be("Install postgres chart on kind");
-        }
-
-        [Test]
-        public void GetPortMappingShouldReturnCorrectMap()
-        {
-            AutoFake.Resolve<PostgresChart>().GetPortMapping()
-                .Should().BeEquivalentTo(new ExtraPortMapping[]
+    [Test]
+    public void GetPortMappingShouldReturnCorrectMap()
+    {
+        AutoFake.Resolve<PostgresChart>().GetPortMapping()
+            .Should().BeEquivalentTo(new ExtraPortMapping[]
+            {
+                new()
                 {
-                    new()
-                    {
-                        ContainerPort = 30001,
-                        HostPort = 5432,
-                        Protocol = "TCP"
-                    }
-                });
-        }
+                    ContainerPort = 30001,
+                    HostPort = 5432,
+                    Protocol = "TCP"
+                }
+            });
+    }
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<PostgresChart>().Install();
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<PostgresChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<PostgresChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add {RepoName} {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<PostgresChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<PostgresChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<PostgresChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<PostgresChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<PostgresChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Charts/SqlServer/SqlServerChartTests.cs
+++ b/tests/UnitTests/Charts/SqlServer/SqlServerChartTests.cs
@@ -5,91 +5,90 @@ using Kindxt.Extensions;
 using Kindxt.Kind;
 using Kindxt.Processes;
 
-namespace UnitTests.Charts.SqlServer
+namespace UnitTests.Charts.SqlServer;
+
+public class SqlServerChartTests : TestBase
 {
-    public class SqlServerChartTests : TestBase
+    private const string ReleaseName = "sqlserver";
+    private const string Namespace = "default";
+    private const string ChartName = "stable/mssql-linux";
+    private const string RepoUrl = "https://charts.helm.sh/stable";
+    private string _pathConfig = Path.Combine("Charts", "SqlServer", "config.yaml");
+    [SetUp]
+    public void SetUp()
     {
-        private const string ReleaseName = "sqlserver";
-        private const string Namespace = "default";
-        private const string ChartName = "stable/mssql-linux";
-        private const string RepoUrl = "https://charts.helm.sh/stable";
-        private string _pathConfig = Path.Combine("Charts", "SqlServer", "config.yaml");
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<HelmProcess>());
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
-                    A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                .Returns(AutoFake.Resolve<HelmProcess>());
-        }
-        [Test]
-        public void ParametersShouldBeCorrect()
-        {
-            AutoFake.Resolve<SqlServerChart>().Parameters
-                .Should().BeEquivalentTo(new string[] { "--sqlserver", "-sql" });
-        }
-        [Test]
-        public void DescriptionShouldBeCorrect()
-        {
-            AutoFake.Resolve<SqlServerChart>().Description
-                .Should().Be("Install sqlserver chart on kind");
-        }
+        AutoFake.Provide(A.Fake<HelmProcess>());
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(A<string>.Ignored,
+                A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+            .Returns(AutoFake.Resolve<HelmProcess>());
+    }
+    [Test]
+    public void ParametersShouldBeCorrect()
+    {
+        AutoFake.Resolve<SqlServerChart>().Parameters
+            .Should().BeEquivalentTo(new string[] { "--sqlserver", "-sql" });
+    }
+    [Test]
+    public void DescriptionShouldBeCorrect()
+    {
+        AutoFake.Resolve<SqlServerChart>().Description
+            .Should().Be("Install sqlserver chart on kind");
+    }
 
-        [Test]
-        public void GetPortMappingShouldReturnCorrectMap()
-        {
-            AutoFake.Resolve<SqlServerChart>().GetPortMapping()
-                .Should().BeEquivalentTo(new ExtraPortMapping[]
+    [Test]
+    public void GetPortMappingShouldReturnCorrectMap()
+    {
+        AutoFake.Resolve<SqlServerChart>().GetPortMapping()
+            .Should().BeEquivalentTo(new ExtraPortMapping[]
+            {
+                new()
                 {
-                    new()
-                    {
-                        ContainerPort = 30000,
-                        HostPort = 1433,
-                        Protocol = "TCP"
-                    }
-                });
-        }
+                    ContainerPort = 30000,
+                    HostPort = 1433,
+                    Protocol = "TCP"
+                }
+            });
+    }
 
-        [Test]
-        public void InstallShouldExecuteCommandRepoAdd()
-        {
-            AutoFake.Resolve<SqlServerChart>().Install();
+    [Test]
+    public void InstallShouldExecuteCommandRepoAdd()
+    {
+        AutoFake.Resolve<SqlServerChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"repo add stable {RepoUrl}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandRepoUpdate()
-        {
-            AutoFake.Resolve<SqlServerChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"repo add stable {RepoUrl}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandRepoUpdate()
+    {
+        AutoFake.Resolve<SqlServerChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    "repo update", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandUninstall()
-        {
-            AutoFake.Resolve<SqlServerChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                "repo update", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandUninstall()
+    {
+        AutoFake.Resolve<SqlServerChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
-                    true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
-        [Test]
-        public void InstallShouldExecuteCommandInstall()
-        {
-            AutoFake.Resolve<SqlServerChart>().Install();
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"uninstall {ReleaseName} -n {Namespace}", A<string>.Ignored,
+                true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+    [Test]
+    public void InstallShouldExecuteCommandInstall()
+    {
+        AutoFake.Resolve<SqlServerChart>().Install();
 
-            A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
-                    $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
-                    KindxtPath.GetProcessPath(),
-                    false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => AutoFake.Resolve<HelmProcess>().ExecuteCommand(
+                $"install {ReleaseName} {ChartName} -n {Namespace} --wait --debug --timeout=5m -f {_pathConfig}",
+                KindxtPath.GetProcessPath(),
+                false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/Kind/KindClusterBuilderTests.cs
+++ b/tests/UnitTests/Kind/KindClusterBuilderTests.cs
@@ -7,127 +7,126 @@ using Kindxt.Managers;
 using Kindxt.Processes;
 using YamlDotNet.Serialization;
 
-namespace UnitTests.Kind
+namespace UnitTests.Kind;
+
+public class KindClusterBuilderTests : TestBase
 {
-    public class KindClusterBuilderTests : TestBase
+    [SetUp]
+    public void SetUp()
     {
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake.Provide(A.Fake<FileManager>());
-            AutoFake.Provide(A.Fake<HelmChartManager>());
-            AutoFake.Provide(A.Fake<KindProcess>());
-            AutoFake.Provide(A.Fake<ProcessWrapper>());
-        }
+        AutoFake.Provide(A.Fake<FileManager>());
+        AutoFake.Provide(A.Fake<HelmChartManager>());
+        AutoFake.Provide(A.Fake<KindProcess>());
+        AutoFake.Provide(A.Fake<ProcessWrapper>());
+    }
 
-        [Test]
-        public void ShouldntCreateDirectoryIfParameterToCreateClusterIsNotSpecified()
-        {
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { "--99" }.ToList());
+    [Test]
+    public void ShouldntCreateDirectoryIfParameterToCreateClusterIsNotSpecified()
+    {
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { "--99" }.ToList());
 
-            A.CallTo(() =>
-                AutoFake.Resolve<FileManager>().CreateDirectoryIfNotExists(A<string>.Ignored))
-                .MustNotHaveHappened();
-        }
+        A.CallTo(() =>
+            AutoFake.Resolve<FileManager>().CreateDirectoryIfNotExists(A<string>.Ignored))
+            .MustNotHaveHappened();
+    }
 
-        [TestCase("--create-cluster")]
-        [TestCase("-c")]
-        public void ShouldCreateDirectoryIfContainsParameterCreateCluster(string parameter)
-        {
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
+    [TestCase("--create-cluster")]
+    [TestCase("-c")]
+    public void ShouldCreateDirectoryIfContainsParameterCreateCluster(string parameter)
+    {
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
 
-            A.CallTo(() =>
-                AutoFake.Resolve<FileManager>().CreateDirectoryIfNotExists(A<string>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+            AutoFake.Resolve<FileManager>().CreateDirectoryIfNotExists(A<string>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [TestCase("--create-cluster")]
-        [TestCase("-c")]
-        public void ShouldWriteFileWhenCreateClusterIsSpecified(string parameter)
-        {
-            var configText = "config";
-            var tmpDirectory = Path.Combine(KindxtPath.GetProcessPath(), "tmp", "kind");
+    [TestCase("--create-cluster")]
+    [TestCase("-c")]
+    public void ShouldWriteFileWhenCreateClusterIsSpecified(string parameter)
+    {
+        var configText = "config";
+        var tmpDirectory = Path.Combine(KindxtPath.GetProcessPath(), "tmp", "kind");
 
-            A.CallTo(() => AutoFake.Resolve<ISerializer>().Serialize(A<object>.Ignored)).Returns(configText);
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
+        A.CallTo(() => AutoFake.Resolve<ISerializer>().Serialize(A<object>.Ignored)).Returns(configText);
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
 
-            A.CallTo(() =>
-                AutoFake.Resolve<FileManager>().WriteFile(Path.Combine(tmpDirectory, "kind-config.yaml"), configText))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+            AutoFake.Resolve<FileManager>().WriteFile(Path.Combine(tmpDirectory, "kind-config.yaml"), configText))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [TestCase("--create-cluster")]
-        [TestCase("-c")]
-        public void ShouldExecuteCommandDeleteClusterWhenParameterCreateClusterIsPresent(string parameter)
-        {
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
+    [TestCase("--create-cluster")]
+    [TestCase("-c")]
+    public void ShouldExecuteCommandDeleteClusterWhenParameterCreateClusterIsPresent(string parameter)
+    {
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
 
-            A.CallTo(() =>
-                AutoFake.Resolve<KindProcess>().ExecuteCommand("delete cluster", "", true, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+            AutoFake.Resolve<KindProcess>().ExecuteCommand("delete cluster", "", true, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [TestCase("--create-cluster")]
-        [TestCase("-c")]
-        public void ShouldExecuteCommandCreateCluster(string parameter)
-        {
-            var tmpDirectory = Path.Combine(KindxtPath.GetProcessPath(), "tmp", "kind");
+    [TestCase("--create-cluster")]
+    [TestCase("-c")]
+    public void ShouldExecuteCommandCreateCluster(string parameter)
+    {
+        var tmpDirectory = Path.Combine(KindxtPath.GetProcessPath(), "tmp", "kind");
 
-            A.CallTo(() => AutoFake.Resolve<KindProcess>()
-                    .ExecuteCommand(A<string>.Ignored, A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
-                    .Returns(AutoFake.Resolve<KindProcess>());
+        A.CallTo(() => AutoFake.Resolve<KindProcess>()
+                .ExecuteCommand(A<string>.Ignored, A<string>.Ignored, A<bool>.Ignored, A<int>.Ignored))
+                .Returns(AutoFake.Resolve<KindProcess>());
 
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { parameter }.ToList());
 
-            A.CallTo(() =>
-                AutoFake.Resolve<KindProcess>()
-                    .ExecuteCommand("create cluster --config=kind-config.yaml -v 1", tmpDirectory, false, A<int>.Ignored))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() =>
+            AutoFake.Resolve<KindProcess>()
+                .ExecuteCommand("create cluster --config=kind-config.yaml -v 1", tmpDirectory, false, A<int>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [Test]
-        public void ShouldAddPortMappingFromIdentifiedHelmCharts()
-        {
-            var helmChart = A.Fake<IHelmChart>();
-            var kindConfig = A.Fake<KindConfig>();
-            var portMapping = A.Fake<ExtraPortMapping>();
-            var listPortMapping = new ExtraPortMapping[] { portMapping };
+    [Test]
+    public void ShouldAddPortMappingFromIdentifiedHelmCharts()
+    {
+        var helmChart = A.Fake<IHelmChart>();
+        var kindConfig = A.Fake<KindConfig>();
+        var portMapping = A.Fake<ExtraPortMapping>();
+        var listPortMapping = new ExtraPortMapping[] { portMapping };
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<IDeserializer>().Deserialize<KindConfig>(A<TextReader>.Ignored))
-                .Returns(kindConfig);
+        A.CallTo(() =>
+                AutoFake.Resolve<IDeserializer>().Deserialize<KindConfig>(A<TextReader>.Ignored))
+            .Returns(kindConfig);
 
-            A.CallTo(() => helmChart.GetPortMapping())
-                .Returns(listPortMapping);
+        A.CallTo(() => helmChart.GetPortMapping())
+            .Returns(listPortMapping);
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<HelmChartManager>().GetHelmCharts(A<List<string>>.Ignored))
-                .Returns(new List<IHelmChart>() { helmChart });
+        A.CallTo(() =>
+                AutoFake.Resolve<HelmChartManager>().GetHelmCharts(A<List<string>>.Ignored))
+            .Returns(new List<IHelmChart>() { helmChart });
 
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { "123" }.ToList());
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { "123" }.ToList());
 
-            A.CallTo(() => kindConfig.AddPortsRange(listPortMapping))
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => kindConfig.AddPortsRange(listPortMapping))
+            .MustHaveHappenedOnceExactly();
+    }
 
-        [Test]
-        public void ShouldInstallHelmChartsIdentifiedByParameters()
-        {
-            var helmChart = A.Fake<IHelmChart>();
-            var kindConfig = A.Fake<KindConfig>();
+    [Test]
+    public void ShouldInstallHelmChartsIdentifiedByParameters()
+    {
+        var helmChart = A.Fake<IHelmChart>();
+        var kindConfig = A.Fake<KindConfig>();
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<IDeserializer>().Deserialize<KindConfig>(A<TextReader>.Ignored))
-                .Returns(kindConfig);
+        A.CallTo(() =>
+                AutoFake.Resolve<IDeserializer>().Deserialize<KindConfig>(A<TextReader>.Ignored))
+            .Returns(kindConfig);
 
-            A.CallTo(() =>
-                    AutoFake.Resolve<HelmChartManager>().GetHelmCharts(A<List<string>>.Ignored))
-                .Returns(new List<IHelmChart>() { helmChart });
+        A.CallTo(() =>
+                AutoFake.Resolve<HelmChartManager>().GetHelmCharts(A<List<string>>.Ignored))
+            .Returns(new List<IHelmChart>() { helmChart });
 
-            AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { "123" }.ToList());
+        AutoFake.Resolve<KindClusterBuilder>().Build(new string[] { "123" }.ToList());
 
-            A.CallTo(() => helmChart.Install())
-                .MustHaveHappenedOnceExactly();
-        }
+        A.CallTo(() => helmChart.Install())
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/UnitTests/TestBase.cs
+++ b/tests/UnitTests/TestBase.cs
@@ -1,15 +1,14 @@
 using Autofac.Extras.FakeItEasy;
 
-namespace UnitTests
-{
-    public class TestBase
-    {
-        protected AutoFake AutoFake;
+namespace UnitTests;
 
-        [SetUp]
-        public void SetUp()
-        {
-            AutoFake = new AutoFake();
-        }
+public class TestBase
+{
+    protected AutoFake AutoFake;
+
+    [SetUp]
+    public void SetUp()
+    {
+        AutoFake = new AutoFake();
     }
 }


### PR DESCRIPTION
This PR changes a lot of files to use the file-scoped namespace feature from C# 10. It also changes de Citus port on the README file to 5433.